### PR TITLE
feat: increment sensors_plus version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -106,7 +106,7 @@ packages:
       name: sensors_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "2.0.2"
   sensors_plus_platform_interface:
     dependency: transitive
     description:
@@ -114,13 +114,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.3"
-  sensors_plus_web:
-    dependency: transitive
-    description:
-      name: sensors_plus_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  sensors_plus: ^1.4.1
+  sensors_plus: ^2.0.1
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Need to increment the sensors_plus version because of this errors:

```dart
Because alice >=0.3.0 depends on sensors_plus ^2.0.1 and shake 2.2.0 depends on sensors_plus ^1.4.1, alice >=0.3.0 is incompatible with shake 2.2.0.
And because no versions of shake match >2.2.0 <3.0.0 and every version of ep_dependencies from path depends on alice ^0.3.2, shake ^2.2.0 is incompatible with ep_dependencies from path.
So, because ep_common depends on ep_dependencies from path which depends on shake ^2.2.0, version solving failed.
pub get failed (1; So, because ep_common depends on ep_dependencies from path which depends on shake ^2.2.0, version solving failed.)
```